### PR TITLE
Fehler „407 Proxyauthentifizierung erforderlich“ vermeiden

### DIFF
--- a/Create-CVEReport.ps1
+++ b/Create-CVEReport.ps1
@@ -264,6 +264,8 @@ return $HTML
 
 #Download JSON Feed
 try {
+	[System.Net.WebRequest]::DefaultWebProxy = [System.Net.WebRequest]::GetSystemWebProxy()
+	[System.Net.WebRequest]::DefaultWebProxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
 	write-output "Downloading CVE Feed"
 	$DownloadFeed = Invoke-WebRequest $NISTFeedURL -OutFile "$PSScriptRoot\jsonfeed.zip"
 }


### PR DESCRIPTION
Fehler 407 beim Download des ZIP-Archives vermeiden.