### PR TITLE
Added capability to use a ConfigurationFile as an alternative to hardcoding configuration into the script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/ReportedCVEs.csv
+/jsonfeed.*
+/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/CVE-Reporter.conf
 /ReportedCVEs.csv
 /jsonfeed.*
 /*.json

--- a/CVE-Reporter.conf.sample
+++ b/CVE-Reporter.conf.sample
@@ -1,0 +1,12 @@
+[MailSettings]
+SMTPServer=SMTPServerNameOrIP
+Sender=cvereporter@domain.tld
+Recipient=recipient@domain.tld
+Subject=CVE Report
+
+[SearchPatterns]
+*Windows*Server*
+*Exchange*Server*
+*vCenter*
+*ESXi*
+*vmware*

--- a/Create-CVEReport.ps1
+++ b/Create-CVEReport.ps1
@@ -12,6 +12,7 @@
 	.\Create-CVEReport.ps1
 .INPUTS
 	No Input requierd, you have to change E-Mail Settings and search pattern inside this script
+	Alternatively, you can provide a ConfigurationFile
 .OUTPUTS
 	HTML E-Mail Report
 	Console Log
@@ -23,8 +24,21 @@
 
 #--------------------------------
 
+[Cmdletbinding()]
+Param (
+	[Parameter(Mandatory=$false)]
+	[String]$ConfigurationFile
+)
+
+#use default path for ConfigurationFile, if none was given
+if (!$ConfigurationFile) {
+	$ConfigurationFile = "$PSScriptRoot\CVE-Reporter.conf"
+}
+
+#--------------------------------
+
 #Search Pattern
-$SearchPatternList=@(
+$SearchPatternList=[System.Collections.ArrayList]@(
 	"*Windows*Server*",
 	"*Exchange*Server*",
 	"*vCenter*",
@@ -36,9 +50,37 @@ $SearchPatternList=@(
 $SMTPServer = "SMTPServerNameOrIP"
 $Sender = "cvereporter@domain.tld"
 $Recipient = "recipient@domain.tld"
-$Subject = "CVE Report" 
+$Subject = "CVE Report"
 
 #--------------------------------
+
+#Import ConfigurationFile, if present
+if (Test-Path $ConfigurationFile) {
+	$SearchPatternList.Clear()
+	foreach ($line in $(Get-Content -LiteralPath $ConfigurationFile)) {
+		$k = [regex]::Match($line,'\[(.*)\]')
+		if ($k.Success -and $k.Groups.Count -eq 2) {
+			$ConfigSection = $k.Groups[1].Value
+		} else {
+			switch ($ConfigSection) {
+				'MailSettings' {
+					$k = [regex]::Split($line,'=')
+					if ($k[0].CompareTo("") -ne 0 -and $k[0].StartsWith("[") -ne $True) {
+						switch ($k[0]) {
+							'SMTPServer' { $SMTPServer = $k[1] }
+							'Sender'     { $Sender = $k[1] }
+							'Recipient'  { $Recipient = $k[1] }
+							'Subject'    { $Subject = $k[1] }
+						}
+					}
+				}
+				'SearchPatterns' {
+					$SearchPatternList.Add($line) | Out-Null
+				}
+			}
+		}
+	}
+}
 
 #Download URL NIST CVE Feed
 $NISTFeedURL = "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-recent.json.zip"

--- a/Create-CVEReport.ps1
+++ b/Create-CVEReport.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-	Creates an E-Mail Report with CVEs matches search pattern
+	Creates an E-Mail Report with CVEs matching search pattern
 .DESCRIPTION
 	This script will download NIST recent CVE data feed and searches for given keywords.
 	Based on search pattern this script generates an HTML E-Mail report with CVEs and
@@ -11,7 +11,7 @@
 .EXAMPLE
 	.\Create-CVEReport.ps1
 .INPUTS
-	No Input requierd, you have to change E-Mail Settings and search pattern insinde this script
+	No Input requierd, you have to change E-Mail Settings and search pattern inside this script
 .OUTPUTS
 	HTML E-Mail Report
 	Console Log

--- a/Create-CVEReport.ps1
+++ b/Create-CVEReport.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-	Creates an E-Mail Report with CVEs matching search pattern
+	Creates an E-Mail Report with CVEs matching given search pattern
 .DESCRIPTION
 	This script will download NIST recent CVE data feed and searches for given keywords.
 	Based on search pattern this script generates an HTML E-Mail report with CVEs and


### PR DESCRIPTION
There might be reasons not to hardcode configuration into the script, such as Updates to the script or Code-Signature (which would be invalidated by changing any hardcoded configuration).  
Therefore I created a ConfigurationFile and extended your script with some code to import the configuration from the ConfigurationFile.

## Usage

* You can Invoke the script with the Parameter -ConfigurationFile to explicitly provide a ConfigurationFile, _or_
* You can invoke the script without the Parameter -ConfigurationFile, in that case the script will automatically check for a file `CVE-Reporter.conf` inside it's own directory and use that.

If a ConfigurationFile is not provided in any of the above ways, the script will continue using it's hardcoded configuration.

## Configuration

Take `CVE-Reporter.conf.sample` as basis and adjust it's Sections according to your needs:
* MailSettings can easily be changed by adjusting the Values (of those Key-Value-Pairs);
* SearchPatterns is just read as a list, each line in that Section will be imported as a SearchPattern;