### PR TITLE
Update Create-CVEReport.ps1

### DIFF
--- a/Create-CVEReport.ps1
+++ b/Create-CVEReport.ps1
@@ -383,7 +383,7 @@ foreach ($CVEID in $CVEsToReport) {
 	$CVE = $CVEList | where {$_.cve.CVE_data_meta.id -eq $CVEID}
 	$CVELastUpdate = $CVE.lastModifiedDate | get-date -Format "yyyyMMddHH"
 		if ($ReportedCSVs.CVEID -contains $CVEID) {
-			$CVEReportDate = ($ReportedCSVs | where {$_.CVEID -match $CVEID}).CVEReportTimeStamp
+			$CVEReportDate = ($ReportedCSVs | Where-Object {$_.CVEID -match $CVEID} | Sort-Object -Property CVEReportTimeStamp -Descending)[0].CVEReportTimeStamp
 			if ($CVELastUpdate -le $CVEReportDate) {
 				write-output "$CVEID already reported and not modified, not sending CVE again"
 				$AddCVEtoReport = $False


### PR DESCRIPTION
Wenn ein CVE mehrfach reported wird, also folglich auch mehrfach in ReportedCVEs.csv vorkommt, empfiehlt sich lediglich den letzten Report-Zeitstempel zu verwenden, um etwaige Änderungen seit dem letzten Report jeweiligen CVEs zu erkennen... (die Liste möglicher Zeitstempel einfach absteigend sortieren und nur den ersten Wert verwenden, klappt für 1 bis n Elemente, 0 Elemente kann es an dieser Stelle im Code zur Ausführungszeit nicht geben)